### PR TITLE
Add `mingw-w64-pragtical`

### DIFF
--- a/mingw-w64-pragtical/0001-pragtical-meson-fix-install.patch
+++ b/mingw-w64-pragtical/0001-pragtical-meson-fix-install.patch
@@ -1,0 +1,15 @@
+--- a/meson.build
++++ b/meson.build
+@@ -227,9 +227,9 @@
+ # Install Configuration
+ #===============================================================================
+ if get_option('portable') or host_machine.system() == 'windows'
+-    pragtical_bindir = '/'
+-    pragtical_docdir = '/doc'
+-    pragtical_datadir = '/data'
++    pragtical_bindir = 'bin'
++    pragtical_docdir = 'share/doc/pragtical'
++    pragtical_datadir = 'share/pragtical'
+     configure_file(
+         input: 'resources/windows/pragtical.exe.manifest.in',
+         output: 'pragtical.exe.manifest',

--- a/mingw-w64-pragtical/PKGBUILD
+++ b/mingw-w64-pragtical/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
+
+_realname=pragtical
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='The practical and pragmatic code editor. (mingw-w64)'
+arch=('any')
+mingw_arch=('ucrt64' 'clang64' 'clangarm64')
+msys2_references=(
+  'archlinux: pragtical'
+)
+msys2_repository_url='https://github.com/pragtical/pragtical'
+url='https://pragtical.dev/'
+license=('spdx:MIT')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-freetype"
+  "${MINGW_PACKAGE_PREFIX}-lua"
+  "${MINGW_PACKAGE_PREFIX}-pcre2"
+  "${MINGW_PACKAGE_PREFIX}-SDL2"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-ninja"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+)
+source=("https://github.com/pragtical/pragtical/archive/v${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "0001-pragtical-meson-fix-install.patch")
+sha256sums=('5dcde10164ff769aa5c6eb8a91d517421f0c70e3ac87f2c6ed536b6cb6b509da'
+            '2e3da169123c34e059d78e63557f5c6e0e89b1e3fd377b3af69a6e6c44928b82')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-pragtical-meson-fix-install.patch"
+}
+
+build() {
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+    "${MINGW_PREFIX}"/bin/meson.exe setup \
+      --prefix="${MINGW_PREFIX}" \
+      --wrap-mode=nodownload \
+      --auto-features=enabled \
+      --buildtype=plain \
+      -Duse_system_lua=true \
+      ${_realname}-${pkgver} \
+      build-${MSYSTEM}
+
+  "${MINGW_PREFIX}"/bin/meson.exe compile -C build-${MSYSTEM}
+}
+
+package() {
+  "${MINGW_PREFIX}"/bin/meson.exe install -C build-${MSYSTEM} --destdir "${pkgdir}"
+}


### PR DESCRIPTION
I know that this is the wrong repository. But the build scripts for `lite-xl` and `pragtical` are very similar. You are the maintainer of `lite-xl`. You can maintain `pragtical` too without much effort. Please help. Thank you.

p/s: I can't become the maintainer of `mingw-w64-pragtical`. Someone who has to browse the internet using a mobile phone can't be the maintainer. The build script for `mingw-w64-pragtical` is not even tested. I'm very sorry about that.